### PR TITLE
`errors.New` with annotators

### DIFF
--- a/annotator.go
+++ b/annotator.go
@@ -4,7 +4,15 @@ type AnnotatorFunc func(*Error)
 
 func WithMessage(message string) AnnotatorFunc {
 	return func(err *Error) {
-		err.message = message
+		if message == "" {
+			return
+		}
+
+		if err.message == "" {
+			err.message = message
+		} else {
+			err.message = message + ": " + err.message
+		}
 	}
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -34,6 +34,17 @@ func TestNew(t *testing.T) {
 		if len(cErr.StackTrace()) == 0 {
 			t.Errorf("expected stack trace, got empty")
 		}
+		if v, ok := cErr.Attributes()["key"]; !ok {
+			t.Errorf("unexpected attributes")
+		} else {
+			vStr, ok := v.(string)
+			if !ok {
+				t.Fatal("unexpected type")
+			}
+			if vStr != "value" {
+				t.Errorf("expected value, got %s", vStr)
+			}
+		}
 	})
 }
 


### PR DESCRIPTION
Before:
```go
errors.Wrap(errors.New("message"), errors.Attr("key", "value"))
```

After:
```go
errors.New("message", errors.Attr("key", "value"))
```